### PR TITLE
Fix imports

### DIFF
--- a/genmock/main.go
+++ b/genmock/main.go
@@ -261,7 +261,6 @@ func addImportsToMock(mockAst *ast.File, fset *token.FileSet, imports []*ast.Imp
 		for i := 0; i < len(mockAst.Decls); i++ {
 			d := mockAst.Decls[i]
 			switch d.(type) {
-			case *ast.FuncDecl:
 			case *ast.GenDecl:
 				dd := d.(*ast.GenDecl)
 				if dd.Tok == token.IMPORT {

--- a/genmock/main.go
+++ b/genmock/main.go
@@ -252,11 +252,6 @@ func addImportsToMock(mockAst *ast.File, fset *token.FileSet, imports []*ast.Imp
 			}
 		}
 	}
-
-	for _, u := range usedImports {
-		r := u.(*ast.ImportSpec)
-		fmt.Println(r.Name, r.Path.Value)
-	}
 	if len(usedImports) > 0 {
 		for i := 0; i < len(mockAst.Decls); i++ {
 			d := mockAst.Decls[i]


### PR DESCRIPTION
This adds the imports to the mockAst.Decls and cleans them at the same time to remove any Pos, Comments and other things brought over from their respective ast. It also sets the ImportsSpec to an empty struct so that there is only 1 source of truth for the imports.