### PR TITLE
Sort package imports before building the mock

### DIFF
--- a/genmock/main.go
+++ b/genmock/main.go
@@ -631,7 +631,7 @@ func generateMockFromAst(o *options, node ast.Node) bool {
 
 		code, err = gofumpt.Source(code, gofumpt.Options{LangVersion: "1.19", ExtraRules: true})
 		if err != nil {
-			fmt.Printf("Failed to apply gofmt formatting for the source code for %s: %v", o.outfile, err)
+			fmt.Printf("Failed to apply gofumpt formatting for the source code for %s: %v", o.outfile, err)
 			os.Exit(1)
 		}
 

--- a/genmock/main.go
+++ b/genmock/main.go
@@ -622,6 +622,11 @@ func generateMockFromAst(o *options, node ast.Node) bool {
 	if v.interfaceType != nil {
 		// We found our interface!
 		var err error
+
+		// We want the package imports to be ordered consistently. This is so that
+		// calling `genmock` is idempotent.
+		sort.Slice(v.imports, func(i, j int) bool { return v.imports[i].Path.Value < v.imports[j].Path.Value })
+
 		code := buildMockForInterface(o, v.interfaceType, v.imports, node)
 
 		code, err = gofumpt.Source(code, gofumpt.Options{LangVersion: "1.19", ExtraRules: true})


### PR DESCRIPTION
I was finding that repeated calls to `genmock` were producing different outputs. Specifically, the imports were being permuted. This branch should resolve the problem.